### PR TITLE
Honor --debug option during parsing and processing

### DIFF
--- a/bin/hermesmail
+++ b/bin/hermesmail
@@ -18,6 +18,7 @@ require "hermes/cli/pop"
 module Hermes
 
   class Processed < Mail
+    attr_accessor :debug
 
     class Done < Exception ; end
 
@@ -55,10 +56,12 @@ module Hermes
 
     class <<self
       attr_accessor :failed_process
-      def process input
+      def process input, debug=false
         i = parse input
+        i.debug = debug
         i.execute
       rescue
+        raise if debug
         open_failed { |f|
           log_exception "Error while parsing mail", f.path
           f.write input
@@ -92,6 +95,7 @@ module Hermes
       save
     rescue Done
     rescue
+      raise if @debug
       log_exception "Error while processing mail"
       b = cls.box cls.failed_process
       save b
@@ -232,7 +236,7 @@ to write one.
       else
         msg = $<.read
         msg.force_encoding Encoding::ASCII_8BIT
-        Processed.process msg
+        Processed.process msg, @debug
       end
     end
 

--- a/bin/hermesmail
+++ b/bin/hermesmail
@@ -172,6 +172,7 @@ to write one.
     def initialize *args
       @quiet = 0
       super
+      $*.replace @args
     end
 
     RULESFILE = "~/.hermesmail-rules"


### PR DESCRIPTION
The normal error messages aren't very helpful in determining the source of problems, so I tried using the `--debug` option. At first that just failed because of the issue addressed by the first commit in this series. After I addressed that it still didn't provide any help because the errors were being suppressed before the exception handler from `Appl` that honors that flag, so I added code to honor that flag in the main exception handlers in hermesmail.
